### PR TITLE
Remove >= from cabal-version

### DIFF
--- a/hs-bibutils.cabal
+++ b/hs-bibutils.cabal
@@ -24,7 +24,7 @@ license:            GPL
 license-file:       LICENSE
 author:             Andrea Rossato
 maintainer:         Václav Haisman <vhaisman@gmail.com>
-cabal-version:      >= 1.16
+cabal-version:      1.16
 build-type:         Simple
 extra-source-files:
         bibutils/adsout.c bibutils/adsout_journals.c bibutils/bibcore.c


### PR DESCRIPTION
Fixes the following warning:
```
Warning: hs-bibutils.cabal:27:28: Packages with 'cabal-version: 1.12' or later
should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 1.16'.
```